### PR TITLE
Edit volume control keys: toggle mute

### DIFF
--- a/rc.lua.blackburn
+++ b/rc.lua.blackburn
@@ -748,12 +748,9 @@ globalkeys = awful.util.table.join(
                                        vicious.force({ volumewidget })
                                      end),
     awful.key({ "Control" }, "m", function ()
-                                       awful.util.spawn("amixer set Master playback mute", false )
+                                       awful.util.spawn("amixer set Master playback toggle", false )
                                        vicious.force({ volumewidget })
                                      end),
-    awful.key({ "Control" }, "u", function ()
-                                      awful.util.spawn("amixer set Master playback unmute", false )
-                                      vicious.force({ volumewidget })
                                   end),
     awful.key({ altkey, "Control" }, "m",
                                   function ()


### PR DESCRIPTION
Mute is now toggled when pressing the mute key, instead of having a mute and an unmute key.
