### PR TITLE
Using "env" command for other command's locations.

### DIFF
--- a/scripts/dfs
+++ b/scripts/dfs
@@ -42,14 +42,14 @@ PATTERN="/"
 
 case "$SYSTEM" in
 "Linux" )
-DF_COMMAND="/bin/df -k"
-SORT_COMMAND="/usr/bin/sort -k6"
-AWK_COMMAND="/bin/awk"
+DF_COMMAND="/usr/bin/env df -k"
+SORT_COMMAND="/usr/bin/env sort -k6"
+AWK_COMMAND="/usr/bin/env awk"
 ;;
 * )
 DF_COMMAND="/bin/df -k"
 SORT_COMMAND="/usr/bin/sort -k6"
-AWK_COMMAND="/opt/local/bin/gawk"
+AWK_COMMAND="/usr/bin/env gawk"
 ;;
 esac
 


### PR DESCRIPTION
Currently, commands path like "awk" are attached to the author's environment. Using "env" the script is not hard coupled to any distribution.
