### PR TITLE
Git submodule commands in root directory

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ Using git: ::
 
     git clone https://github.com/copycat-killer/awesome-copycats.git
     mv -u awesome-copycats ~/.config/awesome
-    cd ~/.config/awesome/lain
+    cd ~/.config/awesome
     git submodule init
     git submodule update
 


### PR DESCRIPTION
Before git clone, lain/ directory is empty.
git submodule commands should be executed in ~/.config/awesome
