### PR TITLE
Fix borderless for max layout

### DIFF
--- a/rc.lua.multicolor
+++ b/rc.lua.multicolor
@@ -692,17 +692,19 @@ for s = 1, screen.count() do screen[s]:connect_signal("arrange", function ()
         local layout  = awful.layout.getname(awful.layout.get(s))
 
         if #clients > 0 then -- Fine grained borders and floaters control
+            local i = 1
             for _, c in pairs(clients) do -- Floaters always have borders
                 if awful.client.floating.get(c) or layout == "floating" then
                     c.border_width = beautiful.border_width
 
                 -- No borders with only one visible client
                 elseif #clients == 1 or layout == "max" then
-                    clients[1].border_width = 0
-                    awful.client.moveresize(0, 0, 2, 2, clients[1])
+                    clients[i].border_width = 0
+                    awful.client.moveresize(0, 0, 2, 2, clients[i])
                 else
                     c.border_width = beautiful.border_width
                 end
+                i = i + 1
             end
         end
       end)


### PR DESCRIPTION
For each window you open on a screen in max layout, the problem becomes more evident: The arrange signal handler is called for each window (not only the one in the front), while in its loop

```
elseif #clients == 1 or layout == "max" then
    clients[1].border_width = 0
    awful.client.moveresize(0, 0, 2, 2, clients[1])
else
```

client[1] from the table is resized each time. The more windows you stack, this leads to one slightly oversized window, while the others stayed the same.

This also lead to some new windows strangely getting placed on the wrong taskbar in my multi-monitor setup (Windows opens on the right screen but is in the left taskbar). This seems to have gone away, too.
