### PR TITLE
Use awful's getdir() to handle XDG_CONFIG_HOME

### DIFF
--- a/rc.lua.blackburn
+++ b/rc.lua.blackburn
@@ -58,10 +58,10 @@ run_once("compton")
 os.setlocale(os.getenv("LANG"))
 
 -- home path
-homedir = os.getenv("HOME") .. "/.config/awesome/"
+homedir = awful.util.getdir("config")
 
 -- beautiful init
-beautiful.init(awful.util.getdir("config") .. "/themes/blackburn/theme.lua")
+beautiful.init(homedir .. "/themes/blackburn/theme.lua")
 
 -- common
 modkey     = "Mod4"

--- a/themes/blackburn/theme.lua
+++ b/themes/blackburn/theme.lua
@@ -7,7 +7,7 @@
 
 theme                               = {}
 
-theme.dir                           = os.getenv("HOME") .. "/.config/awesome/themes/blackburn"
+theme.dir                           = awful.util.getdir("config") .. "/themes/blackburn"
 theme.wallpaper                     = theme.dir .. "/wall.png"
 theme.topbar_path                   = "png:" .. theme.dir .. "/icons/topbar/"
 

--- a/themes/copland/theme.lua
+++ b/themes/copland/theme.lua
@@ -7,7 +7,7 @@
 
 theme                                           = {}
 
-theme.dir                                       = os.getenv("HOME") .. "/.config/awesome/themes/copland"
+theme.dir                                       = awful.util.getdir("config") .. "/themes/copland"
 theme.wallpaper                                 = theme.dir .. "/wall.png"
 
 theme.font                                      = "Tamsyn 10.5"

--- a/themes/dremora/theme.lua
+++ b/themes/dremora/theme.lua
@@ -7,7 +7,7 @@
 
 theme                               = {}
 
-theme.dir                           = os.getenv("HOME") .. "/.config/awesome/themes/dremora"
+theme.dir                           = awful.util.getdir("config") .. "/themes/dremora"
 theme.wallpaper                     = theme.dir .. "/wall.png"
 
 theme.font                          = "Tamsyn 10.5"

--- a/themes/holo/theme.lua
+++ b/themes/holo/theme.lua
@@ -7,9 +7,9 @@
 
 theme                               = {}
 
-theme.icon_dir                      = os.getenv("HOME") .. "/.config/awesome/themes/holo/icons"
+theme.icon_dir                      = awful.util.getdir("config") .. "/themes/holo/icons"
 
-theme.wallpaper                     = os.getenv("HOME") .. "/.config/awesome/themes/holo/wall.png"
+theme.wallpaper                     = theme.dir .. "/wall.png"
 
 theme.topbar_path                   = "png:" .. theme.icon_dir .. "/topbar/"
 

--- a/themes/multicolor/theme.lua
+++ b/themes/multicolor/theme.lua
@@ -8,7 +8,7 @@
 
 theme                               = {}
 
-theme.confdir                       = os.getenv("HOME") .. "/.config/awesome/themes/multicolor"
+theme.confdir                       = awful.util.getdir("config") .. "/themes/multicolor"
 theme.wallpaper                     = theme.confdir .. "/wall.png"
 
 theme.font                          = "Terminus 8"

--- a/themes/powerarrow-darker/theme.lua
+++ b/themes/powerarrow-darker/theme.lua
@@ -7,7 +7,7 @@
 
 theme                               = {}
 
-themes_dir                          = os.getenv("HOME") .. "/.config/awesome/themes/powerarrow-darker"
+themes_dir                          = awful.util.getdir("config") .. "/themes/powerarrow-darker"
 theme.wallpaper                     = themes_dir .. "/wall.png"
 
 theme.font                          = "Terminus 9"

--- a/themes/rainbow/theme.lua
+++ b/themes/rainbow/theme.lua
@@ -7,7 +7,7 @@
 
 theme                               = {}
 
-theme.dir                           = os.getenv("HOME") .. "/.config/awesome/themes/rainbow"
+theme.dir                           = awful.util.getdir("config") .. "/themes/rainbow"
 theme.wallpaper                     = theme.dir .. "/wall.png"
 
 theme.font                          = "Tamsyn 10.5"

--- a/themes/steamburn/theme.lua
+++ b/themes/steamburn/theme.lua
@@ -7,7 +7,7 @@
 
 theme                               = {}
 
-themes_dir                          = os.getenv("HOME") .. "/.config/awesome/themes/steamburn"
+themes_dir                          = awful.util.getdir("config") .. "/themes/steamburn"
 theme.wallpaper                     = themes_dir .. "/wall.png"
 
 theme.font                          = "Tamsyn 10.5"


### PR DESCRIPTION
For those of us who have `XDG_CONFIG_HOME` set the hard coded `~/.config` locations may be incorrect.  This change uses `awful`'s `getdir()` to access the [correct directory](http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html).

There is a remote possibility for breakage should a current user have set `XDG_CONFIG_HOME`, but accepted that this repo is going to live in `~/.config/awesome`.  Not sure if, or how, that should be handled.

Thanks,

James
