### PR TITLE
fix: promptbox was created but not added to layout

### DIFF
--- a/rc.lua.holo
+++ b/rc.lua.holo
@@ -386,6 +386,7 @@ for s = 1, screen.count() do
     left_layout:add(mytaglist[s])
     left_layout:add(spr_small)
     left_layout:add(mylayoutbox[s])
+    left_layout:add(mypromptbox[s])
 
     -- Widgets that are aligned to the upper right
     local right_layout = wibox.layout.fixed.horizontal()


### PR DESCRIPTION
Prompt & Lua Prompt (Mod4 r/x) were functionnal (expected effect when pressing Enter) but did not display anything on screen.

The corresponding widget was initialized but never actually added to the layout
