### PR TITLE
Copland theme: Fixing the bat widget icon

### DIFF
--- a/rc.lua.copland
+++ b/rc.lua.copland
@@ -193,7 +193,7 @@ batupd = lain.widgets.bat({
                 baticon:set_image(beautiful.bat_low)
             else
                 batbar:set_color("#EB8F8F")
-                baticon:set_image(beautiful.bat_no)
+                baticon:set_image(beautiful.bat_empty)
 
             end
 


### PR DESCRIPTION
Not sure if this is intentional or a small oversight:

Right now, the Copland battery widget displays no battery icon when the battery percentage is <=15.
It tries to display bat_no, which does not exist.

I replaced it with bat_empty as defined in the beautiful theme.
