### PR TITLE
Copland: Fixing bad widget color

### DIFF
--- a/rc.lua.copland
+++ b/rc.lua.copland
@@ -190,6 +190,7 @@ batupd = lain.widgets.bat({
                 batbar:set_color(beautiful.fg_normal)
                 baticon:set_image(beautiful.bat)
             elseif bat_perc > 15 then
+                batbar:set_color(beautiful.fg_normal)
                 baticon:set_image(beautiful.bat_low)
             else
                 batbar:set_color("#EB8F8F")


### PR DESCRIPTION
Thanks for your great Copland theme! I really like it (without the titlebars though xD).

Anyway, this is a small fix for the Copland battery widget.

**Bug description:** 
If your bat percentage drops below 14%, the bar color changes to a red-pink tone.
But if you recharge the battery and the percentage raises above 14% again (but is still lower than 51%) the red color remains.

This commit corrects this behaviour (so you always get a grey bar if bat_perc > 15).
