### PR TITLE
remove useless invocations of awful.client.moveresize()

### DIFF
--- a/rc.lua.blackburn
+++ b/rc.lua.blackburn
@@ -636,7 +636,6 @@ for s = 1, screen.count() do screen[s]:connect_signal("arrange", function ()
                 -- No borders with only one visible client
                 elseif #clients == 1 or layout == "max" then
                     clients[1].border_width = 0
-                    awful.client.moveresize(0, 0, 2, 2, clients[1])
                 else
                     c.border_width = beautiful.border_width
                 end

--- a/rc.lua.copland
+++ b/rc.lua.copland
@@ -729,7 +729,6 @@ for s = 1, screen.count() do screen[s]:connect_signal("arrange", function ()
                 -- No borders with only one visible client
                 elseif #clients == 1 or layout == "max" then
                     clients[1].border_width = 0
-                    awful.client.moveresize(0, 0, 2, 2, clients[1])
                 else
                     c.border_width = beautiful.border_width
                 end

--- a/rc.lua.dremora
+++ b/rc.lua.dremora
@@ -665,7 +665,6 @@ for s = 1, screen.count() do screen[s]:connect_signal("arrange", function ()
                 -- No borders with only one visible client
                 elseif #clients == 1 or layout == "max" then
                     clients[1].border_width = 0
-                    awful.client.moveresize(0, 0, 2, 2, clients[1])
                 else
                     c.border_width = beautiful.border_width
                 end

--- a/rc.lua.holo
+++ b/rc.lua.holo
@@ -771,7 +771,6 @@ for s = 1, screen.count() do screen[s]:connect_signal("arrange", function ()
                 -- No borders with only one visible client
                 elseif #clients == 1 or layout == "max" then
                     clients[1].border_width = 0
-                    awful.client.moveresize(0, 0, 2, 2, clients[1])
                 else
                     c.border_width = beautiful.border_width
                 end

--- a/rc.lua.powerarrow-darker
+++ b/rc.lua.powerarrow-darker
@@ -688,7 +688,6 @@ for s = 1, screen.count() do screen[s]:connect_signal("arrange", function ()
                 -- No borders with only one visible client
                 elseif #clients == 1 or layout == "max" then
                     clients[1].border_width = 0
-                    awful.client.moveresize(0, 0, 2, 2, clients[1])
                 else
                     c.border_width = beautiful.border_width
                 end

--- a/rc.lua.rainbow
+++ b/rc.lua.rainbow
@@ -634,7 +634,6 @@ for s = 1, screen.count() do screen[s]:connect_signal("arrange", function ()
                 -- No borders with only one visible client
                 elseif #clients == 1 or layout == "max" then
                     clients[1].border_width = 0
-                    awful.client.moveresize(0, 0, 2, 2, clients[1])
                 else
                     c.border_width = beautiful.border_width
                 end

--- a/rc.lua.steamburn
+++ b/rc.lua.steamburn
@@ -643,7 +643,6 @@ for s = 1, screen.count() do screen[s]:connect_signal("arrange", function ()
                 -- No borders with only one visible client
                 elseif #clients == 1 or layout == "max" then
                     clients[1].border_width = 0
-                    awful.client.moveresize(0, 0, 2, 2, clients[1])
                 else
                     c.border_width = beautiful.border_width
                 end


### PR DESCRIPTION
in most themes this is not required - changing the border_size will
reposition the window to accompany the changed total size.

Also the useless resizes do hurt terminals if some of the "window size
changed" events got lost or garbeled. Also some reported lags (awesome
bug FS#1181 - Clients resize lag).
