### PR TITLE
Fixing Freedesktop for awesome wm on arch full updated

### DIFF
--- a/rc.lua.blackburn
+++ b/rc.lua.blackburn
@@ -101,9 +101,9 @@ end
 -- }}}
 
 -- {{{ Menu
-require("freedesktop/freedesktop")
+--require("freedesktop/freedesktop")
 -- }}}
-
+require('freedesktop.utils')
 -- {{{ Wibox
 markup = lain.util.markup
 gray   = "#9E9C9A"

--- a/rc.lua.copland
+++ b/rc.lua.copland
@@ -112,9 +112,9 @@ end
 -- }}}
 
 -- {{{ Menu
-require("freedesktop/freedesktop")
+--require("freedesktop/freedesktop")
 -- }}}
-
+require('freedesktop.utils')
 -- {{{ Wibox
 markup = lain.util.markup
 blue   = beautiful.fg_focus

--- a/rc.lua.dremora
+++ b/rc.lua.dremora
@@ -101,8 +101,10 @@ end
 -- }}}
 
 -- {{{ Menu
-require("freedesktop/freedesktop")
+--require("freedesktop/freedesktop")
 -- }}}
+
+require('freedesktop.utils')
 
 -- {{{ Wibox
 markup = lain.util.markup

--- a/rc.lua.holo
+++ b/rc.lua.holo
@@ -102,8 +102,10 @@ end
 -- }}}
 
 -- {{{ Menu
-require("freedesktop/freedesktop")
+--require("freedesktop/freedesktop")
 -- }}}
+
+require('freedesktop.utils')
 
 -- {{{ Wibox
 markup = lain.util.markup

--- a/rc.lua.multicolor
+++ b/rc.lua.multicolor
@@ -107,8 +107,10 @@ end
 -- }}}
 
 -- {{{ Freedesktop Menu
-require("freedesktop/freedesktop")
+--require("freedesktop/freedesktop")
 -- }}}
+
+require('freedesktop.utils')
 
 -- {{{ Wibox
 markup      = lain.util.markup

--- a/rc.lua.powerarrow-darker
+++ b/rc.lua.powerarrow-darker
@@ -104,8 +104,11 @@ end
 -- }}}
 
 -- {{{ Menu
-require("freedesktop/freedesktop")
+--require("freedesktop/freedesktop")
 -- }}}
+
+require('freedesktop.utils')
+
 
 -- {{{ Wibox
 markup = lain.util.markup

--- a/rc.lua.rainbow
+++ b/rc.lua.rainbow
@@ -108,8 +108,10 @@ end
 -- }}}
 
 -- {{{ Menu
-require("freedesktop/freedesktop")
+--require("freedesktop/freedesktop")
 -- }}}
+
+require('freedesktop.utils')
 
 -- {{{ Wibox
 markup = lain.util.markup

--- a/rc.lua.steamburn
+++ b/rc.lua.steamburn
@@ -106,8 +106,10 @@ end
 -- }}}
 
 -- {{{ Menu
-require("freedesktop/freedesktop")
+--require("freedesktop/freedesktop")
 -- }}}
+
+require('freedesktop.utils')
 
 -- {{{ Wibox
 markup = lain.util.markup


### PR DESCRIPTION
Hi, i really appreciate your work. I was testing ur themas on my notebook and i problem.
I am running Archlinux full updated (3.14.4-1-ARCH) with awesome wm full updated (awesome v3.5.5) and Lua 5.2.3.

I got some problemas with freedesktop so i made 1 line changes to solve the problem.

Thank you for your work, and have a nice day.
