### PR TITLE
Vertex: Properly center using expand = "none"

### DIFF
--- a/themes/vertex/theme.lua
+++ b/themes/vertex/theme.lua
@@ -426,23 +426,24 @@ function theme.at_screen_connect(s)
     -- Create the wibox
     s.mywibox = awful.wibar({ position = "top", screen = s, height = 25, bg = gears.color.create_png_pattern(theme.panelbg) })
 
+    local wiboxlayout = wibox.layout.align.horizontal()
+    wiboxlayout.expand = "none"
     -- Add widgets to the wibox
     s.mywibox:setup {
-        layout = wibox.layout.align.horizontal,
+        layout = wiboxlayout,
         { -- Left widgets
             layout = wibox.layout.fixed.horizontal,
             s.mypromptbox,
             tspace1,
-            wibox.container.constraint(s.mytasklist, "exact", s.workarea.width/2.6),
+            s.mytasklist,
         },
         { -- Middle widgets
-            layout = wibox.layout.flex.horizontal,
-            space,
+            layout = wibox.layout.fixed.horizontal,
             mytextclock,
         },
         { -- Right widgets
             layout = wibox.layout.fixed.horizontal,
-            wibox.container.constraint(wibox.widget { nil, nil, theme.mpd.widget, layout = wibox.layout.align.horizontal }, "exact", s.workarea.width/3),
+            wibox.widget { nil, nil, theme.mpd.widget, layout = wibox.layout.align.horizontal },
             rspace0,
             theme.weather.icon,
             theme.weather.widget,


### PR DESCRIPTION
Previous behaviour would not center the text clock, also the textclock would get 'squashed' and time would not be visible if, for example, a long command is typed into the prompt or there are too many icons in the systray.

By setting the align.horizontal layout to "none", this guarantees textclock will be in the middle, and that any overflow of right/left widgets do not affect it. Much neater behaviour. Also allows removing arbitray calculation for constraints based on workarea width.