### PR TITLE
Powerarrow-dark: fix calendar widget attaching.

### DIFF
--- a/themes/powerarrow-dark/theme.lua
+++ b/themes/powerarrow-dark/theme.lua
@@ -99,7 +99,7 @@ local clock = awful.widget.watch(
 
 -- Calendar
 theme.cal = lain.widget.calendar({
-    attach_to = { clock.widget },
+    attach_to = { clock },
     notification_preset = {
         font = "xos4 Terminus 10",
         fg   = theme.fg_normal,


### PR DESCRIPTION
Now calendar is showing when you mouse over clock widget.