### PR TITLE
remove duplicate assign of theme.cal

### DIFF
--- a/themes/multicolor/theme.lua
+++ b/themes/multicolor/theme.lua
@@ -99,7 +99,7 @@ local mytextclock = wibox.widget.textclock(markup("#7788af", "%A %d %B ") .. mar
 mytextclock.font = theme.font
 
 -- Calendar
-theme.cal = theme.cal = lain.widget.cal({
+theme.cal = lain.widget.cal({
     attach_to = { mytextclock },
     notification_preset = {
         font = "xos4 Terminus 10",

--- a/themes/powerarrow-dark/theme.lua
+++ b/themes/powerarrow-dark/theme.lua
@@ -100,7 +100,7 @@ local clock = awful.widget.watch(
 )
 
 -- Calendar
-theme.cal = theme.cal = lain.widget.cal({
+theme.cal = lain.widget.cal({
     attach_to = { clock },
     notification_preset = {
         font = "xos4 Terminus 10",

--- a/themes/powerarrow/theme.lua
+++ b/themes/powerarrow/theme.lua
@@ -108,7 +108,7 @@ local binclock = require("themes.powerarrow.binclock"){
 }
 
 -- Calendar
-theme.cal = theme.cal = lain.widget.cal({
+theme.cal = lain.widget.cal({
     --cal = "cal --color=always",
     attach_to = { binclock.widget },
     notification_preset = {


### PR DESCRIPTION
The themes `multicolor`, `powerarrow` and `powerarrow-dark` have a duplicate assign of `theme.cal` that leads to error. This pull request removes the duplicates. 