### PR TITLE
Wrong assignment on powerarrow/theme.lua

### DIFF
--- a/themes/powerarrow/theme.lua
+++ b/themes/powerarrow/theme.lua
@@ -10,7 +10,7 @@ local lain  = require("lain")
 local awful = require("awful")
 local wibox = require("wibox")
 
-local math, string, os = os, math, string, os
+local math, string, os = math, string, os
 local my_table = awful.util.table or gears.table -- 4.{0,1} compatibility
 
 local theme                                     = {}


### PR DESCRIPTION
Hello,

it seems the commit https://github.com/lcpz/awesome-copycats/commit/de166423c943d96542ea59c278ee027966a133be#diff-719f5d5458a39eceffd6f8a8f252c8cd had a small gap in the file theme.lua of the theme powerarrow.