### PR TITLE
Use a logical 'and' before removal command.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,7 +97,7 @@ Installation
 .. code-block:: shell
 
     $ git clone --recursive https://github.com/lcpz/awesome-copycats.git
-    $ mv -bv awesome-copycats/* ~/.config/awesome; rm -rf awesome-copycats
+    $ mv -bv awesome-copycats/* ~/.config/awesome && rm -rf awesome-copycats
 
 Usage
 =====


### PR DESCRIPTION
If the user doesn't have awesome's config installed to the given
directory, the first `mv` command will fail and the repository files
removed thereafter. To prevent this from happening, use a logical
`and` instead. The user then has the opportunity to create the directory
and re-run instead of having to re-clone.