### PR TITLE
Fix useless gaps shortcut not working

### DIFF
--- a/rc.lua.template
+++ b/rc.lua.template
@@ -353,9 +353,9 @@ globalkeys = my_table.join(
         {description = "toggle wibox", group = "awesome"}),
 
     -- On the fly useless gaps change
-    awful.key({ altkey, "Control" }, "+", function () lain.util.useless_gaps_resize(1) end,
+    awful.key({ altkey, "Control" }, "+", function () beatiful.useless_gaps = beatiful.useless_gaps + 1 end,
               {description = "increment useless gaps", group = "tag"}),
-    awful.key({ altkey, "Control" }, "-", function () lain.util.useless_gaps_resize(-1) end,
+    awful.key({ altkey, "Control" }, "-", function () beatiful.useless_gaps = beatiful.useless_gaps - 1 end,
               {description = "decrement useless gaps", group = "tag"}),
 
     -- Dynamic tagging


### PR DESCRIPTION
This PR fixes the shortcuts for the built-in useless gaps functionality in awesome wm. I couldn't get it to work with the lain gaps so I just use the awesome wm built in gaps instead.