### PR TITLE
Using string.format() on the net widget in powerarrow-dark.

### DIFF
--- a/themes/powerarrow-dark/theme.lua
+++ b/themes/powerarrow-dark/theme.lua
@@ -247,9 +247,9 @@ local neticon = wibox.widget.imagebox(theme.widget_net)
 local net = lain.widget.net({
     settings = function()
         widget:set_markup(markup.font(theme.font,
-                          markup("#7AC82E", " " .. net_now.received)
+                          markup("#7AC82E", " " .. string.format("%06.1f", net_now.received))
                           .. " " ..
-                          markup("#46A8C3", " " .. net_now.sent .. " ")))
+                          markup("#46A8C3", " " .. string.format("%06.1f", net_now.sent) .. " ")))
     end
 })
 


### PR DESCRIPTION
As the net usage varies, so the numbers on the widget does. The problem is
that it makes the whole widget bar to go back and forth as the numbers change.
Adding a 'padding' number of zeroes reduces the number of 'moves' of the
widget row, and does not reduces the visibility of the widgets.