### PR TITLE
adding keyboard layout widget to powerarrow-dark

### DIFF
--- a/themes/powerarrow-dark/theme.lua
+++ b/themes/powerarrow-dark/theme.lua
@@ -91,6 +91,8 @@ theme.titlebar_maximized_button_normal_inactive = theme.dir .. "/icons/titlebar/
 local markup = lain.util.markup
 local separators = lain.util.separators
 
+local keyboardlayout = awful.widget.keyboardlayout:new()
+
 -- Textclock
 local clockicon = wibox.widget.imagebox(theme.widget_clock)
 local clock = awful.widget.watch(
@@ -316,6 +318,7 @@ function theme.at_screen_connect(s)
         { -- Right widgets
             layout = wibox.layout.fixed.horizontal,
             wibox.widget.systray(),
+            keyboardlayout,
             spr,
             arrl_ld,
             wibox.container.background(mpdicon, theme.bg_focus),


### PR DESCRIPTION
Per title. The widget is in the first position, right after the system tray.