### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,7 +96,7 @@ Installation
 
 .. code-block:: shell
 
-    $ git clone --recursive https://github.com/lcpz/awesome-copycats.git
+    $ git clone --depth 1 --recursive https://github.com/lcpz/awesome-copycats.git
     $ mv -bv awesome-copycats/* ~/.config/awesome && rm -rf awesome-copycats
 
 Usage


### PR DESCRIPTION
No need to clone whole repository since we are removing it anyway. With this change users will not need to download whole git history of this repo.