### PR TITLE
Update themes/powerarrow-dark/theme.lua

### DIFF
--- a/themes/powerarrow-dark/theme.lua
+++ b/themes/powerarrow-dark/theme.lua
@@ -137,7 +137,7 @@ theme.mail = lain.widget.imap({
 local musicplr = awful.util.terminal .. " -title Music -g 130x34-320+16 -e ncmpcpp"
 local mpdicon = wibox.widget.imagebox(theme.widget_music)
 mpdicon:buttons(my_table.join(
-    awful.button({ modkey }, 1, function () awful.spawn.with_shell(musicplr) end),
+    awful.button({ "Mod4" }, 1, function () awful.spawn(musicplr) end),
     awful.button({ }, 1, function ()
         os.execute("mpc prev")
         theme.mpd.update()


### PR DESCRIPTION
1. The 'modkey' used on line 140 hasn't been declared before, therefore the function won't be executed.
2. Change awful.spawn.with_shell() to awful.spawn()