### PR TITLE
remove \$ from `Installation` copy paste code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,14 +96,14 @@ Installation
 
 .. code-block:: shell
 
-    $ git clone --recurse-submodules --remote-submodules --depth 1 -j 2 https://github.com/lcpz/awesome-copycats.git
-    $ mv -bv awesome-copycats/{*,.[^.]*} ~/.config/awesome; rm -rf awesome-copycats
+    git clone --recurse-submodules --remote-submodules --depth 1 -j 2 https://github.com/lcpz/awesome-copycats.git
+    mv -bv awesome-copycats/{*,.[^.]*} ~/.config/awesome; rm -rf awesome-copycats
 
 In case you do not want the Git files, use the following as the second command:
 
 .. code-block:: shell
 
-    $ mv -bv awesome-copycats/* ~/.config/awesome; rm -rf awesome-copycats
+    mv -bv awesome-copycats/* ~/.config/awesome; rm -rf awesome-copycats
 
 Usage
 =====


### PR DESCRIPTION
`Installation`  code block isnt copy paste'able since it includes the dollar symbol ($)  
Lets fix it for users by making the copyable code work :)

```bash
$ $ git clone --recurse-submodules --remote-submodules --depth 1 -j 2 https://github.com/lcpz/awesome-copycats.git
$ mv -bv awesome-copycats/{*,.[^.]*} ~/.config/awesome; rm -rf awesome-copycats
bash: $: command not found
bash: $: command not found
```
