### PR TITLE
(multicolor) Fix fs widget

### DIFF
--- a/themes/multicolor/theme.lua
+++ b/themes/multicolor/theme.lua
@@ -130,7 +130,7 @@ local fsicon = wibox.widget.imagebox(theme.widget_fs)
 theme.fs = lain.widget.fs({
     notification_preset = { font = "Terminus 10", fg = theme.fg_normal },
     settings  = function()
-        widget:set_markup(markup.fontfg(theme.font, "#80d9d8", string.format("%.1f", fs_now["/"].used) .. "% "))
+        widget:set_markup(markup.fontfg(theme.font, "#80d9d8", string.format("%.1f", fs_now["/"].percentage) .. "% "))
     end
 })
 --]]


### PR DESCRIPTION
- fix: use correct disk percentage
  - This was the original value. It was changed in https://github.com/lcpz/awesome-copycats/commit ad6d3f2eb5b8a3f06834d347a9cd548080213852 because (according to commit message) it stopped working. Now, it seems to be working again.
- ~fix: fs pop-up spacing/alignment~
  - ~Using a non-monospaced font for the pop-up text caused the text to be misaligned. See: https://github.com/lcpz/lain/wiki/fs#note. This PR removes the custom font, letting the widget popup default to the `Monospace 10` font as per lain [docs](https://github.com/lcpz/lain/wiki/fs#default-notification_preset).~