### PR TITLE
xdg-autostart: Fall back to default XDG variable values

### DIFF
--- a/rc.lua.template
+++ b/rc.lua.template
@@ -76,7 +76,8 @@ awful.spawn.with_shell(
     'if (xrdb -query | grep -q "^awesome\\.started:\\s*true$"); then exit; fi;' ..
     'xrdb -merge <<< "awesome.started:true";' ..
     -- list each of your autostart commands, followed by ; inside single quotes, followed by ..
-    'dex --environment Awesome --autostart --search-paths "$XDG_CONFIG_DIRS/autostart:$XDG_CONFIG_HOME/autostart"' -- https://github.com/jceb/dex
+    'dex --environment Awesome --autostart --search-paths ' ..
+    '"${XDG_CONFIG_HOME:-$HOME/.config}/autostart:${XDG_CONFIG_DIRS:-/etc/xdg}/autostart";') -- https://github.com/jceb/dex
 )
 --]]
 

--- a/rc.lua.template
+++ b/rc.lua.template
@@ -77,7 +77,7 @@ awful.spawn.with_shell(
     'xrdb -merge <<< "awesome.started:true";' ..
     -- list each of your autostart commands, followed by ; inside single quotes, followed by ..
     'dex --environment Awesome --autostart --search-paths ' ..
-    '"${XDG_CONFIG_HOME:-$HOME/.config}/autostart:${XDG_CONFIG_DIRS:-/etc/xdg}/autostart";') -- https://github.com/jceb/dex
+    '"${XDG_CONFIG_HOME:-$HOME/.config}/autostart:${XDG_CONFIG_DIRS:-/etc/xdg}/autostart";' -- https://github.com/jceb/dex
 )
 --]]
 


### PR DESCRIPTION
For example, $XDG_RUNTIME_DIR might be unset in Debian 12